### PR TITLE
Support additional request parameters introduced in v1.9 + dev

### DIFF
--- a/projects/ng-oidc-client/src/lib/models/arguments.model.ts
+++ b/projects/ng-oidc-client/src/lib/models/arguments.model.ts
@@ -20,4 +20,7 @@ export interface RequestArugments {
   request?: any;
   request_uri?: string;
   extraQueryParams?: any;
+  extraTokenParams?: any; // https://github.com/IdentityModel/oidc-client-js/issues/745 
+  skipUserInfo?: boolean; // https://github.com/IdentityModel/oidc-client-js/issues/825
+  response_mode?: string; // https://github.com/IdentityModel/oidc-client-js/commit/5fbce7cfe529a706a99366bc5024c07dee024103#diff-daf6bf2d1b132f4a29f19d017b195b7c
 }


### PR DESCRIPTION
There were a couple of request attributes added to oidc-client-js that are not supported so far by ng-oidc-client. 

- extraTokenParams (see https://github.com/IdentityModel/oidc-client-js/issues/745)
- skipUserInfo (see https://github.com/IdentityModel/oidc-client-js/issues/825)
- response_mode (see https://github.com/IdentityModel/oidc-client-js/commit/5fbce7cfe529a706a99366bc5024c07dee024103#diff-daf6bf2d1b132f4a29f19d017b195b7c)